### PR TITLE
fix: reverse the bits (before into ByteVariable) to correspond to `to_le_bytes`

### DIFF
--- a/plonky2x/core/src/backend/wrapper/wrap.rs
+++ b/plonky2x/core/src/backend/wrapper/wrap.rs
@@ -80,7 +80,12 @@ where
                 .collect();
 
             bits.chunks_exact(ByteVariable::nb_elements())
-                .map(ByteVariable::from_targets)
+                .map(|bits| {
+                    // Reverse the bits to correspond with `u64::to_le_bytes`.
+                    let mut bits = bits.to_vec();
+                    bits.reverse();
+                    ByteVariable::from_targets(&bits)
+                })
                 .collect()
         })
     }


### PR DESCRIPTION
### Summary

To make the output-hash could be calculated as:
```
// Convert the inputs to le bytes
let inputs = inputs.to_le_bytes();
// Sha256
let mut hasher = sha2::Sha256::new();
hasher.update(pi_bytes);
let mut hash: [u8; 32] = hasher.finalize().into();
// Truncate the first 3-bits
hash[0] = hash[0] & 0x1f;
```